### PR TITLE
[update]カート一覧が空時の情報入力画面修正

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -1,10 +1,10 @@
 class Public::CartItemsController < ApplicationController
-  
+
   def index
     @cart_items = current_customer.cart_items.all
     @total = @cart_items.inject(0) { |sum, item| sum + item.sum_of_price }
   end
-  
+
   def create
         @cart_item = current_customer.cart_items.new(cart_item_params)
         # もし元々カート内に「同じ商品」がある場合、「数量を追加」更新・保存する
@@ -14,7 +14,7 @@ class Public::CartItemsController < ApplicationController
             cart_item.save
             redirect_to cart_items_path
 
-        # もしカート内に「同じ」商品がない場合は通常の保存処理 
+        # もしカート内に「同じ」商品がない場合は通常の保存処理
         elsif @cart_item.save
               @cart_items = current_customer.cart_items.all
             render 'index'
@@ -28,7 +28,7 @@ class Public::CartItemsController < ApplicationController
         @cart_items = CartItem.all
         render 'index'
   end
-        
+
   def destroy
         cart_item = CartItem.find(params[:id])
         cart_item.destroy
@@ -37,16 +37,16 @@ class Public::CartItemsController < ApplicationController
   end
 
   def destroy_all  #カート内全て削除
-        cart_items = CartItem.all
-        cart_items.destroy_all
+        @cart_items = CartItem.all
+        @cart_items.destroy_all
         render 'index'
   end
 
 
-  
+
   private
-  
+
   def cart_item_params
       params.require(:cart_item).permit(:item_id, :price, :quantity)
   end
-end 
+end

--- a/app/views/public/addresses/index.html.erb
+++ b/app/views/public/addresses/index.html.erb
@@ -1,3 +1,4 @@
+<%= flash[:notice] %>
 <h1>配送先登録／一覧</h1>
 <% if @address.errors.any? %>
   <%= @address.errors.count %>件のエラーが発生しました

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -15,7 +15,6 @@
 
 <h4>注文情報入力</h4>
 <%= form_with model: @order, url: "/orders/confirm", method: :post, local: true do |f| %>  
-     :
   <h5>お届け先</h5>
    <%= f.radio_button :address_option, 0, checked: "checked" %>  
       <%= f.label :order_address, "ご自身の住所" %>  


### PR DESCRIPTION
レイアウト修正(注文画面":"削除)
カート一覧画面-->空時の情報入力画面修正
配送先編集時のフラッシュメッセージ表示